### PR TITLE
adds workflow.connect method to simplify building a workflow

### DIFF
--- a/example2.py
+++ b/example2.py
@@ -1,0 +1,31 @@
+from cwlpy import Workflow, WorkflowStep as Step, WorkflowStepConnection as Connection
+from ruamel import yaml
+
+# https://github.com/common-workflow-language/cwl-v1.1/blob/master/tests/revsort.cwl
+# Uses connect method to simplify setting up connections
+
+########################################
+# Create workflow and steps
+########################################
+
+workflow = Workflow('revsort')
+rev_step = Step('rev', run='revtool.cwl')
+sort_step = Step('sorted', run='sorttool.cwl')
+
+# Add steps by chaining
+workflow.step(rev_step).step(sort_step)
+
+########################################
+# Connect workflow and steps
+########################################
+
+# workflow.input -> rev_step.input
+workflow.connect('input', 'rev.input')
+# workflow.reverse_sort -> sort_step.reverse
+workflow.connect('reverse_sort', 'sorted.reverse')
+# rev_step.output -> sort_step.input
+workflow.connect('rev.output', 'sorted.input')
+# sort_step.output -> workflow.output
+workflow.connect('sorted.output', 'output')
+
+print(yaml.safe_dump(workflow.save(), default_flow_style=False))

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -166,7 +166,7 @@ class WorkflowWithStepsTestCase(TestCase):
 
         self.workflow.connect('step2.out_field', 'output_arg')
 
-        self.workflow.connect_output.assert_called_with(step2_obj, 'out_field', 'output_arg')
+        self.workflow.connect_output.assert_called_with(step2_obj, 'output_arg', workflow_output_id='out_field')
         self.workflow.connect_steps.assert_not_called()
         self.workflow.connect_input.assert_not_called()
 


### PR DESCRIPTION
This method internally calls workflow.connect_steps, workflow.connect_output, or workflow.connect_input.